### PR TITLE
Unit tests for error middleware

### DIFF
--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -5,4 +5,21 @@ const expectError = (statusCode, error, response) => {
   })
 }
 
-module.exports = { expectError }
+const expectErrorStatus = (statusCode, expectedStatusCode) => {
+  expect(statusCode).toHaveBeenCalledWith(expectedStatusCode);
+}
+
+const expectJSON = (json, expectedJSON) => {
+  expect(json).toHaveBeenCalledWith(expectedJSON)
+}
+
+const expectLogger = (loggerError, errorMessage) => {
+  expect(loggerError).toHaveBeenCalledWith(errorMessage)
+}
+
+module.exports = {
+  expectError ,
+  expectErrorStatus,
+  expectJSON,
+  expectLogger
+}

--- a/src/test/unit/middlewares/error.spec.js
+++ b/src/test/unit/middlewares/error.spec.js
@@ -119,4 +119,23 @@ describe("Error middleware", () => {
             err.message
         )
     })
+
+    test('Should handle error with status and code', () => {
+        const err = {
+            status: 400,
+            code: "BAD_REQUEST",
+            message: "bad request"
+        }
+
+        errorMiddleware(err, {}, res, next)
+
+        expectErrorHandling(
+            res,
+            logger,
+            err,
+            400,
+            err.code,
+            err.message
+        )
+    })
 })

--- a/src/test/unit/middlewares/error.spec.js
+++ b/src/test/unit/middlewares/error.spec.js
@@ -1,0 +1,44 @@
+const errorMiddleware = require("~/middlewares/error")
+const {
+    INTERNAL_SERVER_ERROR,
+    DOCUMENT_ALREADY_EXISTS,
+    MONGO_SERVER_ERROR,
+    VALIDATION_ERROR
+} = require('~/consts/errors')
+const logger = require('~/logger/logger')
+const getUniqueFields = require('~/utils/getUniqueFields')
+
+jest.mock('~/logger/logger')
+jest.mock('~/utils/getUniqueFields')
+
+describe("Error middleware", () => {
+    let res, next;
+
+    beforeEach(() => {
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis()
+        }
+        next = jest.fn()
+    })
+
+    test('Should handle MongoServerError with 11000 code', () => {
+        const err = {
+            name: "MongoServerError",
+            code: 11000,
+            message: 'duplicate key error collection: test.users index: email_1 dup key: { email: "test@example.com" }'
+        }
+
+        getUniqueFields.mockReturnValue('email')
+        errorMiddleware(err, {}, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(409)
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            status: 409,
+            code: DOCUMENT_ALREADY_EXISTS('email').code,
+            message: DOCUMENT_ALREADY_EXISTS('email').message,
+        }))
+        expect(logger.error).toHaveBeenCalledWith(err)
+        expect(getUniqueFields).toHaveBeenCalledWith(err.message)
+    })
+})

--- a/src/test/unit/middlewares/error.spec.js
+++ b/src/test/unit/middlewares/error.spec.js
@@ -41,4 +41,22 @@ describe("Error middleware", () => {
         expect(logger.error).toHaveBeenCalledWith(err)
         expect(getUniqueFields).toHaveBeenCalledWith(err.message)
     })
+
+    test('Should handle MongoServerError with non-11000 code', () => {
+        const err = {
+            name: "MongoServerError",
+            code: 12345,
+            message: "some non-11000 mongo error"
+        }
+
+        errorMiddleware(err, {}, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            status: 500,
+            code: MONGO_SERVER_ERROR(err.message).code,
+            message: MONGO_SERVER_ERROR(err.message).message
+        }))
+        expect(logger.error).toHaveBeenCalledWith(err)
+    })
 })

--- a/src/test/unit/middlewares/error.spec.js
+++ b/src/test/unit/middlewares/error.spec.js
@@ -59,4 +59,21 @@ describe("Error middleware", () => {
         }))
         expect(logger.error).toHaveBeenCalledWith(err)
     })
+
+    test('Should handle ValidationError', () => {
+        const err = {
+            name: "ValidationError",
+            message: "validation failed"
+        }
+
+        errorMiddleware(err, {}, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(409)
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            status: 409,
+            code: VALIDATION_ERROR(err.message).code,
+            message: VALIDATION_ERROR(err.message).message
+        }))
+        expect(logger.error).toHaveBeenCalledWith(err)
+    })
 })


### PR DESCRIPTION
This PR introduces unit tests for error middleware, covering all outcomes as defined in error middleware implementation.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/30a936d2-44e5-4c82-9e25-fb67ca543b2c">

Closes #29 