### PR TITLE
"Add category" endpoint

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -1,0 +1,22 @@
+const categoryService = require('~/services/category')
+const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+const { createError } = require("~/utils/errorsHelper");
+
+const createCategory = async (req, res) => {
+    const categoryData = req.body
+
+    try {
+        const newCategory = await categoryService.createCategory({ ...categoryData })
+        res.status(201).json(newCategory)
+    } catch (error) {
+        if (error.code && error.message) {
+            throw error
+        }
+
+        throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+}
+
+module.exports = {
+    createCategory
+}

--- a/src/docs/schemas/category/create-category.js
+++ b/src/docs/schemas/category/create-category.js
@@ -1,0 +1,25 @@
+module.exports = {
+    CreateCategoryRequest: {
+        type: 'object',
+        required: ['name', 'icon', 'color'],
+        properties: {
+            name: {
+                type: 'string',
+                description: 'The name of the category. This field is required.',
+                example: 'Electronics'
+            },
+            icon: {
+                type: 'string',
+                description: 'The icon representing the category (URL or icon name). This field is required.',
+                example: 'https://example.com/icon.png',
+                default: 'mocked-path-to-icon'
+            },
+            color: {
+                type: 'string',
+                description: 'The color associated with the category (hex code). This field is required.',
+                example: '#FF5733',
+                default: '#66C42C'
+            }
+        }
+    }
+}

--- a/src/middlewares/swagger.js
+++ b/src/middlewares/swagger.js
@@ -36,6 +36,7 @@ const GetUsersScheme = require('~/docs/schemas/users/get-users')
 const UpdateUserByIdScheme = require('~/docs/schemas/users/update-user-by-id')
 
 const CategoryScheme = require('~/docs/schemas/category/category')
+const CreateCategoryScheme = require('~/docs/schemas/category/create-category')
 
 const options = {
   definition: {
@@ -73,7 +74,8 @@ const options = {
         ...DeleteUserByIdScheme,
         ...GetUsersScheme,
         ...UpdateUserByIdScheme,
-        ...CategoryScheme
+        ...CategoryScheme,
+        ...CreateCategoryScheme
       }
     }
   },

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -1,0 +1,44 @@
+const router = require('express').Router()
+
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const categoryController = require('~/controllers/category')
+const { authMiddleware, restrictTo } = require('~/middlewares/auth')
+
+const {
+    roles: { ADMIN }
+} = require('~/consts/auth')
+
+router.use(authMiddleware)
+router.use(restrictTo(ADMIN))
+
+/**
+ * @swagger
+ * /categories:
+ *   post:
+ *     summary: Create a new category
+ *     tags: [Category]
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateCategoryRequest'
+ *     responses:
+ *       201:
+ *         description: Category created successfully
+ *       400:
+ *         description: Invalid request body or parameters
+ *       401:
+ *         description: Unauthorized access
+ *       403:
+ *         description: Forbidden, insufficient permissions
+ *       409:
+ *         description: Category already exists
+ *       500:
+ *         description: Server error
+ */
+router.post('/', asyncWrapper(categoryController.createCategory))
+
+module.exports = router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ const resourcesCategory = require('~/routes/resourcesCategory')
 const offer = require('~/routes/offer')
 const confirmEmail = require(`~/routes/confirmEmail`)
 const location = require('~/routes/location')
+const category = require('~/routes/category')
 
 router.use('/auth', auth)
 router.use('/users', user)
@@ -19,5 +20,6 @@ router.use('/resources-categories', resourcesCategory)
 router.use('/offers', offer)
 router.use('/confirm-email', confirmEmail)
 router.use('/location', location)
+router.use('/category', category)
 
 module.exports = router

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,0 +1,21 @@
+const Category = require('~/models/category')
+const { createError } = require("~/utils/errorsHelper")
+const { DOCUMENT_ALREADY_EXISTS, BAD_REQUEST } = require('~/consts/errors')
+
+const categoryService = {
+    createCategory: async ({ name, icon, color }) => {
+        if (!name || !icon || !color) {
+            throw createError(400, BAD_REQUEST)
+        }
+
+        const existingCategory = await Category.findOne({ name })
+        if (existingCategory) {
+            throw createError(409, DOCUMENT_ALREADY_EXISTS('name'))
+        }
+
+        const category = new Category({ name, icon, color })
+        return await category.save()
+    }
+}
+
+module.exports = categoryService

--- a/src/test/integration/controllers/category.spec.js
+++ b/src/test/integration/controllers/category.spec.js
@@ -1,0 +1,118 @@
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const categoryService = require('~/services/category')
+const errors = require('~/consts/errors')
+const jwt = require('jsonwebtoken')
+const { createError } = require("~/utils/errorsHelper");
+
+
+describe('Category controller', () => {
+    const mockCategoryData = {
+        name: 'Mathematics',
+        icon: 'mock-icon-path',
+        color: 'mock-color'
+    };
+
+    const mockAdminToken = () => jwt.verify = jest.fn().mockReturnValue({ id: 'admin-id', role: 'admin' })
+    const mockUserToken = () => jwt.verify = jest.fn().mockReturnValue({ id: 'admin-id', role: 'user' })
+    const mockInvalidToken = () => jwt.verify = jest.fn(() => { throw new Error('Invalid token')})
+
+    let app, server
+
+    beforeAll(async () => {
+        ; ({ app, server } = await serverInit())
+    })
+
+    beforeEach(() => {
+        jest.resetAllMocks()
+    })
+
+    afterEach(async () => {
+        await serverCleanup()
+    })
+
+    afterAll(async () => {
+        await stopServer(server)
+    })
+
+    test('Should allow admin to create category', async () => {
+        mockAdminToken()
+
+        const response = await app
+            .post('/category')
+            .set('Cookie', ['accessToken=fake-admin-token'])
+            .send(mockCategoryData)
+
+        expect(response.status).toBe(201)
+    })
+
+    test('Should reject non-admin users', async () => {
+        mockUserToken()
+
+        const response = await app
+            .post('/category')
+            .set('Cookie', ['accessToken=fake-user-token'])
+            .send(mockCategoryData)
+
+        expect(response.status).toBe(403)
+        expect(response.body).toEqual({
+            status: 403,
+            ...errors.FORBIDDEN
+        });
+    })
+
+    test('Should reject requests with invalid token', async () => {
+        mockInvalidToken()
+
+        const response = await app
+            .post('/category')
+            .set('Cookie', ['accessToken=fake-token'])
+            .send(mockCategoryData)
+
+        expect(response.status).toBe(401)
+    })
+
+    test('Should reject requests with no token', async () => {
+        const response = await app
+            .post('/category')
+            .send(mockCategoryData)
+
+        expect(response.status).toBe(401)
+    })
+
+    test('Should reject requests with incomplete body', async () => {
+        mockAdminToken()
+
+        const incompleteData = { name: 'Mathematics' }
+
+        const response = await app
+            .post('/category')
+            .set('Cookie', ['accessToken=fake-admin-token'])
+            .send(incompleteData)
+
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual({
+            status: 400,
+            ...errors.BAD_REQUEST
+        })
+    })
+
+    test('Should handle 500', async () => {
+        mockAdminToken()
+
+        jest.spyOn(categoryService, 'createCategory')
+            .mockImplementation(() => {
+                throw new Error('Unexpected error');
+            });
+
+        const response = await app
+            .post('/category')
+            .set('Cookie', ['accessToken=fake-admin-token'])
+            .send(mockCategoryData)
+
+        expect(response.status).toBe(500)
+        expect(response.body).toEqual({
+            ...createError(500, errors.INTERNAL_SERVER_ERROR),
+            message: ''
+        })
+    })
+})

--- a/src/test/unit/services/category.spec.js
+++ b/src/test/unit/services/category.spec.js
@@ -1,0 +1,41 @@
+const categoryService = require('~/services/category');
+const Category = require('~/models/category')
+const { DOCUMENT_ALREADY_EXISTS } = require('~/consts/errors')
+
+jest.mock('~/models/category')
+
+describe('Category service', () => {
+    const mockCategoryData = {
+        name: 'Mathematics',
+        icon: 'mock-icon-path',
+        color: 'mock-color'
+    }
+
+    test('Should create and return a new category', async () => {
+        Category.findOne = jest.fn().mockResolvedValue(null)
+        Category.prototype.save = jest.fn().mockResolvedValue(mockCategoryData)
+
+        const category = await categoryService.createCategory(mockCategoryData)
+
+        expect(category).toEqual(mockCategoryData)
+        expect(Category.findOne).toHaveBeenCalledWith({ name: 'Mathematics' })
+        expect(Category.prototype.save).toHaveBeenCalled()
+    });
+
+    test('Should throw an error if category already exists', async () => {
+        Category.findOne = jest.fn().mockResolvedValue(mockCategoryData);
+
+        await expect(categoryService.createCategory(mockCategoryData))
+            .rejects.toThrow(DOCUMENT_ALREADY_EXISTS('name'))
+    })
+
+    test('Should reject with missing fields', async () => {
+        const incompleteData = {
+            name: 'Mathematics',
+            icon: 'mock-icon-path',
+        }
+
+        await expect(categoryService.createCategory({ ...incompleteData }))
+            .rejects.toThrow('The request could not be processed due to invalid or missing parameters.')
+    })
+})


### PR DESCRIPTION
# Description
This PR introduces an endpoint for adding a category. Access to the endpoint is provided only for admins. The required service and controller have been implemented, and tests cover both. Swagger docs are updated accordingly.

# Tests
## Service
<img width="647" alt="image" src="https://github.com/user-attachments/assets/efd8b4cb-cdfa-4378-9202-71fd516eb748">

## Controller
<img width="688" alt="image" src="https://github.com/user-attachments/assets/db3208e6-e88d-41ab-ae1c-a07ed8b7c5ef">

# Swagger
## Endpoint
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/b5e46f1b-8298-4d6d-a41e-acd4fadc76b3">

## Schema definitions
<img width="910" alt="image" src="https://github.com/user-attachments/assets/a112c9b3-feb7-4cb0-a459-b37f01cebdac">


Closes #74 