### PR TITLE
'Get Categories' endpoint

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -1,0 +1,14 @@
+const categoryService = require('~/services/category')
+const categoryAggregateOptions = require('~/utils/categories/categoriesAggregateOptions')
+
+const getCategories = async (req, res) => {
+  const pipeline = categoryAggregateOptions(req.query)
+
+  const offers = await categoryService.getCategories(pipeline)
+
+  res.status(200).json(offers)
+}
+
+module.exports = {
+  getCategories
+}

--- a/src/docs/schemas/category/get-categories.js
+++ b/src/docs/schemas/category/get-categories.js
@@ -1,0 +1,18 @@
+module.exports = {
+  GetCategoriesResponse: {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/Category',
+        },
+      },
+      count: {
+        type: 'integer',
+        description: 'The total number of categories available',
+        example: 3,
+      }
+    }
+  }
+}

--- a/src/middlewares/swagger.js
+++ b/src/middlewares/swagger.js
@@ -36,6 +36,7 @@ const GetUsersScheme = require('~/docs/schemas/users/get-users')
 const UpdateUserByIdScheme = require('~/docs/schemas/users/update-user-by-id')
 
 const CategoryScheme = require('~/docs/schemas/category/category')
+const GetCategoriesScheme = require('~/docs/schemas/category/get-categories')
 
 const LessonScheme = require('~/docs/schemas/lesson/lesson')
 
@@ -79,7 +80,8 @@ const options = {
         ...GetUsersScheme,
         ...UpdateUserByIdScheme,
         ...CategoryScheme,
-        ...LessonScheme
+        ...GetCategoriesScheme,
+        ...LessonScheme,
         ...SubjectScheme
       }
     }

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -1,0 +1,81 @@
+const router = require('express').Router()
+
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const categoryController = require('~/controllers/category')
+const { authMiddleware } = require('~/middlewares/auth')
+
+router.use(authMiddleware)
+
+/**
+ * @swagger
+ * /categories:
+ *   get:
+ *     summary: Retrieve a list of categories with optional filtering, sorting, and pagination
+ *     tags: [Categories]
+ *     parameters:
+ *       - in: query
+ *         name: name
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: Filter categories by name (supports partial matching with regex)
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 100
+ *         required: false
+ *         description: The maximum number of categories to return
+ *       - in: query
+ *         name: skip
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *         required: false
+ *         description: The number of categories to skip before starting to collect the result set
+ *     responses:
+ *       200:
+ *         description: A list of categories matching the query, each with its associated subjects
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       _id:
+ *                         type: string
+ *                         description: The category ID
+ *                         example: '1234567890abcdef12345678'
+ *                       name:
+ *                         type: string
+ *                         description: The name of the category
+ *                         example: 'Technology'
+ *                       subjects:
+ *                         type: array
+ *                         description: The list of subjects associated with the category
+ *                         items:
+ *                           type: object
+ *                           properties:
+ *                             _id:
+ *                               type: string
+ *                               description: The subject ID
+ *                               example: 'abcdef1234567890abcdef12'
+ *                             name:
+ *                               type: string
+ *                               description: The name of the subject
+ *                               example: 'AI'
+ *                             category:
+ *                               type: string
+ *                               format: ObjectId
+ *                               description: The ObjectId reference to the associated category
+ *                               example: '1234567890abcdef12345678'
+ *       401:
+ *         description: Unauthorized user
+ */
+router.get('/', asyncWrapper(categoryController.getCategories))
+
+module.exports = router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ const resourcesCategory = require('~/routes/resourcesCategory')
 const offer = require('~/routes/offer')
 const confirmEmail = require(`~/routes/confirmEmail`)
 const location = require('~/routes/location')
+const category = require('~/routes/category')
 
 router.use('/auth', auth)
 router.use('/users', user)
@@ -19,5 +20,6 @@ router.use('/resources-categories', resourcesCategory)
 router.use('/offers', offer)
 router.use('/confirm-email', confirmEmail)
 router.use('/location', location)
+router.use('/categories', category)
 
 module.exports = router

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,0 +1,10 @@
+const Category = require('~/models/category')
+
+const categoryService = {
+  getCategories: async (pipeline) => {
+    const [response] = await Category.aggregate(pipeline).exec()
+    return response
+  }
+}
+
+module.exports = categoryService

--- a/src/test/integration/controllers/category.spec.js
+++ b/src/test/integration/controllers/category.spec.js
@@ -1,0 +1,136 @@
+const mongoose = require('mongoose')
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const tokenService = require('~/services/token')
+const Category = require('~/models/category')
+const Subject = require('~/models/subject')
+
+jest.mock('~/services/token')
+
+const categories = [
+  { _id: mongoose.Types.ObjectId(), name: 'Technology', updatedAt: new Date(), subjects: [] },
+  { _id: mongoose.Types.ObjectId(), name: 'Health', updatedAt: new Date(), subjects: [] },
+  { _id: mongoose.Types.ObjectId(), name: 'Finance', updatedAt: new Date(), subjects: [] }
+]
+
+const subjects = [
+  { _id: mongoose.Types.ObjectId(), name: 'AI', category: categories[0]._id },
+  { _id: mongoose.Types.ObjectId(), name: 'Biology', category: categories[1]._id },
+  { _id: mongoose.Types.ObjectId(), name: 'Finance 101', category: categories[2]._id }
+]
+
+
+describe('Category controller', () => {
+  let app, server
+
+  beforeAll(async () => {
+    ; ({ app, server } = await serverInit())
+  })
+
+  beforeEach(async () => {
+    await Category.deleteMany({});
+    await Category.insertMany(categories);
+
+    await Subject.deleteMany({});
+    await Subject.insertMany(subjects);
+
+    tokenService.validateAccessToken.mockReturnValue({ id: 'userId', role: 'user' });
+  })
+
+  afterEach(async () => {
+    await serverCleanup()
+  })
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  test('Should return all categories with default pagination', async () => {
+    const response = await app
+        .get('/categories')
+        .set('Cookie', `accessToken=validAccessToken`)
+
+
+    expect(response.status).toBe(200)
+    expect(response.body.items.length).toBe(3)
+    expect(response.body.items).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({ name: 'Technology' }),
+            expect.objectContaining({ name: 'Health' }),
+            expect.objectContaining({ name: 'Finance' })
+        ])
+    )
+  })
+
+  test('Should apply pagination correctly', async () => {
+    const response = await app
+        .get('/categories?limit=2&skip=1')
+        .set('Cookie', `accessToken=validAccessToken`)
+
+    console.log(response.body.items)
+    expect(response.status).toBe(200)
+    expect(response.body.items.length).toBe(1)
+    expect(response.body.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Finance' }),
+        ])
+    )
+  })
+
+  test('Should filter categories by name', async () => {
+    const response = await app
+        .get('/categories?name=Tech')
+        .set('Cookie', `accessToken=validAccessToken`)
+
+    expect(response.status).toBe(200)
+    expect(response.body.items.length).toBe(1)
+    expect(response.body.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Technology' }),
+        ])
+    )
+  })
+
+  test('Should return empty result set when no categories match the query', async () => {
+    const response = await app
+        .get('/categories?name=NonExistentCategory')
+        .set('Cookie', `accessToken=validAccessToken`)
+
+    expect(response.status).toBe(200)
+    expect(response.body.items.length).toBe(0)
+  })
+
+  test('Should return all categories when limit exceeds the total count', async () => {
+    const response = await app
+        .get('/categories?limit=100')
+        .set('Cookie', `accessToken=validAccessToken`)
+
+    expect(response.status).toBe(200)
+    expect(response.body.items.length).toBe(3)
+  })
+
+  test('Should exclude categories without subjects', async () => {
+    await Category.create({ _id: mongoose.Types.ObjectId(), name: 'Empty category', updatedAt: new Date(), subjects: []  })
+
+    const response = await app
+        .get('/categories')
+        .set('Cookie', 'accessToken=validAccessToken')
+
+    expect(response.status).toBe(200)
+    expect(response.body.items.length).toBe(3)
+    expect(response.body.items).not.toEqual(
+        expect.arrayContaining(([
+            expect.objectContaining({ name: 'Empty category' })
+        ]))
+    )
+  })
+
+  test('Should throw 401 for unauthorized user', async () => {
+    tokenService.validateAccessToken.mockReturnValue(null)
+
+    const response = await app
+        .get('/categories')
+        .set('Cookie', `accessToken=validAccessToken`)
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/src/test/unit/services/category.spec.js
+++ b/src/test/unit/services/category.spec.js
@@ -1,0 +1,83 @@
+const Category = require('~/models/category')
+const categoryService = require('~/services/category')
+
+jest.mock('~/models/category')
+
+describe('Category service', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('Should return aggregated categories', async () => {
+    const mockPipeline = [
+      {
+        $match: { name: 'Test' }
+      },
+      {
+        $sort: { name: 1 }
+      }
+    ]
+
+    const mockResult = [
+      { '_id': '123', name: 'Test Category' }
+    ]
+
+    Category.aggregate.mockReturnValue({
+      exec: jest.fn().mockResolvedValueOnce([mockResult])
+    })
+
+    const result = await categoryService.getCategories(mockPipeline)
+
+    expect(Category.aggregate).toHaveBeenCalledWith(mockPipeline)
+    expect(result).toEqual(mockResult)
+  })
+
+  test('Should return an empty array when no categories match', async () => {
+    const mockPipeline = [
+      {
+        $match: { name: 'Dummy' }
+      }
+    ]
+
+    Category.aggregate.mockReturnValue({
+      exec: jest.fn().mockResolvedValue([[]])
+    })
+
+    const result = await categoryService.getCategories(mockPipeline)
+
+    expect(Category.aggregate).toHaveBeenCalledWith(mockPipeline)
+    expect(result).toEqual([])
+  })
+
+  test('Should correctly process a complex pipeline', async () => {
+    const mockPipeline = [
+      {
+        $match: { name: { $regex: /test/i } }
+      },
+      {
+        $lookup: {
+          from: 'subjects',
+          localField: '_id',
+          foreignField: 'category',
+          as: 'subjects'
+        }
+      },
+      {
+        $sort: { name: 1 }
+      }
+    ]
+
+    const mockResult = [
+      { '_id': '123', name: 'Test Category', subjects: [] }
+    ]
+
+    Category.aggregate.mockReturnValue({
+      exec: jest.fn().mockResolvedValueOnce([mockResult])
+    })
+
+    const result = await categoryService.getCategories(mockPipeline)
+
+    expect(Category.aggregate).toHaveBeenCalledWith(mockPipeline)
+    expect(result).toEqual(mockResult)
+  })
+})


### PR DESCRIPTION
# Description
This PR introduces an endpoint for fetching categories, considering the aggregation pipeline.
Both the category service and controller are covered by relevant tests. 
Swagger docs have been updated accordingly.

# Tests
## Service
<img width="594" alt="image" src="https://github.com/user-attachments/assets/83312c8b-2d59-4277-9860-5ee65524f549">

## Controller
<img width="715" alt="image" src="https://github.com/user-attachments/assets/2f103f5d-9204-4f56-bd59-914114937d2e">

## Aggregation Pipeline
<img width="403" alt="image" src="https://github.com/user-attachments/assets/26b47836-d7cd-4d95-adb3-e4f03be59aef">

# Swagger
## Endpoint definition
<img width="969" alt="image" src="https://github.com/user-attachments/assets/919c4212-927a-498d-9c3d-243c3303b386">

<img width="1391" alt="image" src="https://github.com/user-attachments/assets/7fe2e88b-af4a-44dc-8e10-22f011461912">


Closes #76 
