### PR TITLE
Template Paths in Email Service

### DIFF
--- a/src/services/email.js
+++ b/src/services/email.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const EmailTemplates = require('email-templates')
 const { sendMail } = require('~/utils/mailer')
 const { templateList } = require('~/emails')
@@ -7,7 +8,11 @@ const {
 const { createError } = require('~/utils/errorsHelper')
 const { TEMPLATE_NOT_FOUND } = require('~/consts/errors')
 
-const emailTemplates = new EmailTemplates()
+const emailTemplates = new EmailTemplates({
+  views: {
+    root: path.join(__dirname, '../emails')
+  }
+})
 
 const emailService = {
   sendEmail: async (email, subject, language, text = {}) => {


### PR DESCRIPTION
This PR introduces a fixed issue in email service, specifically, the path for templates is defined explicitly.
Please make sure to paste the email you want mails to be sent to in your `.env` file.

Closes #103